### PR TITLE
Remove mapId parameter from provider route

### DIFF
--- a/examples/demo-app/src/app.js
+++ b/examples/demo-app/src/app.js
@@ -102,7 +102,7 @@ class App extends Component {
     // if we pass an id as part of the url
     // we ry to fetch along map configurations
     const {
-      params: {id, provider, mapId} = {},
+      params: {id, provider} = {},
       location: {query = {}}
     } = this.props;
 
@@ -110,7 +110,7 @@ class App extends Component {
       const providerHandler = CLOUD_PROVIDERS[provider];
 
       if (providerHandler) {
-        this.props.dispatch(providerHandler.loadMap(mapId, query));
+        this.props.dispatch(providerHandler.loadMap(query));
 
         return;
       }

--- a/examples/demo-app/src/utils/cloud-providers/carto.js
+++ b/examples/demo-app/src/utils/cloud-providers/carto.js
@@ -26,6 +26,7 @@ import {formatCsv} from 'processors/data-processor';
 import {getMapPermalink} from '../url';
 import get from 'lodash.get';
 import {loadRemoteResourceSuccess,setLoadingMapStatus} from '../../actions';
+import {push} from 'react-router-redux';
 
 const NAME = 'carto';
 const carto = new OAuthApp({
@@ -48,7 +49,7 @@ function setAuthToken(authToken) {
 
 /**
  * The CARTO cloud provider polls the created window internally to parse the URL
- * @param {*} location 
+ * @param {*} location
  */
 function getAccessTokenFromLocation(location) {
   return;
@@ -111,10 +112,15 @@ function getAccessToken() {
   return carto.oauth.expired ? null : carto.oauth.token;
 }
 
-function loadMap(mapId, queryParams) {
-  const { owner: username } = queryParams;
+function loadMap(queryParams) {
+  const { owner: username, mapId } = queryParams;
 
   return dispatch => {
+    if (!username || !mapId) {
+      dispatch(push('/demo'));
+      return;
+    }
+
     dispatch(setLoadingMapStatus(true));
     carto.PublicStorageReader.getVisualization(username, mapId).then((result) => {
       // These are the options required for the action. For now, all datasets that come from CARTO are CSV

--- a/examples/demo-app/src/utils/routes.js
+++ b/examples/demo-app/src/utils/routes.js
@@ -45,7 +45,7 @@ export function buildAppRoutes(Component) {
       <Route key="demo" path="demo">
         <IndexRoute component={Component} />
         <Route path="map" component={Component} />
-        <Route path="map/:provider(/:mapId)" component={Component} />
+        <Route path="map/:provider" component={Component} />
         <Route path="(:id)" component={Component} />
       </Route>
     )


### PR DESCRIPTION
This PR removes previously optional parameter `mapId` from map provider route.

Related to https://github.com/CartoDB/kepler.gl/issues/27