### PR TITLE
Fix exception thrown while loading maps from CARTO backend

### DIFF
--- a/examples/demo-app/src/components/map-control/map-control.js
+++ b/examples/demo-app/src/components/map-control/map-control.js
@@ -182,7 +182,10 @@ function SampleMapPanel(props) {
 
 const CustomMapControl = props => (
   <StyledMapControlOverlay>
-    {props.currentSample ? <SampleMapPanel {...props} /> : null}
+    {props.currentSample && !props.currentSample.panelDisabled
+      ? <SampleMapPanel {...props} />
+      : null
+    }
     <MapControl {...props} />
   </StyledMapControlOverlay>
 );

--- a/examples/demo-app/src/components/map-control/map-control.js
+++ b/examples/demo-app/src/components/map-control/map-control.js
@@ -128,7 +128,7 @@ const LinkRenderer = props => {
 
 // convert https://raw.githubusercontent.com/uber-web/kepler.gl-data/master/nyctrips/config.json
 // to https://github.com/uber-web/kepler.gl-data/blob/master/movement_pittsburgh/config.json
-function getURL(url) {
+function getURL(url='') {
   return url
     .replace('https://raw.githubusercontent.com', 'https://github.com')
     .replace('master', 'blob/master');
@@ -152,18 +152,22 @@ function SampleMapPanel(props) {
             />
           </div>
           <div className="project-links">
-            <LinkButton
-              label="Data"
-              href={getURL(props.currentSample.dataUrl)}
-              iconComponent={Icons.Files}
-              height="15px"
-            />
-            <LinkButton
-              label="Config"
-              href={getURL(props.currentSample.configUrl)}
-              iconComponent={Icons.CodeAlt}
-              height="17px"
-            />
+            { props.currentSample.dataUrl &&
+              <LinkButton
+                label="Data"
+                href={getURL(props.currentSample.dataUrl)}
+                iconComponent={Icons.Files}
+                height="15px"
+              />
+            }
+            { props.currentSample.configUrl &&
+              <LinkButton
+                label="Config"
+                href={getURL(props.currentSample.configUrl)}
+                iconComponent={Icons.CodeAlt}
+                height="17px"
+              />
+            }
           </div>
         </StyledProjectPanel>
       ) : (

--- a/examples/demo-app/src/components/map-control/map-control.js
+++ b/examples/demo-app/src/components/map-control/map-control.js
@@ -128,7 +128,7 @@ const LinkRenderer = props => {
 
 // convert https://raw.githubusercontent.com/uber-web/kepler.gl-data/master/nyctrips/config.json
 // to https://github.com/uber-web/kepler.gl-data/blob/master/movement_pittsburgh/config.json
-function getURL(url='') {
+function getURL(url) {
   return url
     .replace('https://raw.githubusercontent.com', 'https://github.com')
     .replace('master', 'blob/master');
@@ -152,22 +152,18 @@ function SampleMapPanel(props) {
             />
           </div>
           <div className="project-links">
-            { props.currentSample.dataUrl &&
-              <LinkButton
-                label="Data"
-                href={getURL(props.currentSample.dataUrl)}
-                iconComponent={Icons.Files}
-                height="15px"
-              />
-            }
-            { props.currentSample.configUrl &&
-              <LinkButton
-                label="Config"
-                href={getURL(props.currentSample.configUrl)}
-                iconComponent={Icons.CodeAlt}
-                height="17px"
-              />
-            }
+            <LinkButton
+              label="Data"
+              href={getURL(props.currentSample.dataUrl)}
+              iconComponent={Icons.Files}
+              height="15px"
+            />
+            <LinkButton
+              label="Config"
+              href={getURL(props.currentSample.configUrl)}
+              iconComponent={Icons.CodeAlt}
+              height="17px"
+            />
           </div>
         </StyledProjectPanel>
       ) : (

--- a/examples/demo-app/src/constants/default-settings.js
+++ b/examples/demo-app/src/constants/default-settings.js
@@ -95,7 +95,7 @@ export const LOADING_SAMPLE_ERROR_MESSAGE = 'Not able to load sample';
 export const LOADING_URL_MESSAGE = 'You can use the following formats: CSV | JSON | Kepler.gl config json. Make sure the url contains the file extension.';
 export const CORS_LINK = 'https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS';
 export const KEPLER_DISCLAIMER = '* Kepler.gl will save your map data to your personal cloud storage, only people with the URL can access your map and data. ' +
-  'You can edit/delete the data file in your Dropbox account anytime.';
+  'You can edit/delete the data in your cloud storage account anytime.';
 
 export const DEFAULT_LOADING_METHOD = LOADING_METHODS[0];
 

--- a/examples/demo-app/src/reducers/index.js
+++ b/examples/demo-app/src/reducers/index.js
@@ -126,7 +126,7 @@ export const loadRemoteResourceSuccess = (state, action) => {
   const datasets = options.map((opt, i) => {
     const datasetId = opt.id || generateHashId(6);
     const { dataUrl } = opt;
-  
+
     let processorMethod = processCsvData;
     // TODO: create helper to determine file ext eligibility
     if (dataUrl.includes('.json') || dataUrl.includes('.geojson')) {
@@ -159,7 +159,7 @@ export const loadRemoteResourceSuccess = (state, action) => {
     ...state,
     app: {
       ...state.app,
-      currentSample: action.options,
+      currentSample: action.options && action.options.length ? action.options[0] : action.options,
       isMapLoading: false // we turn of the spinner
     },
     keplerGl: {

--- a/examples/demo-app/src/reducers/index.js
+++ b/examples/demo-app/src/reducers/index.js
@@ -112,6 +112,12 @@ function arrayify(thing) {
   return Array.isArray(thing) ? thing : [thing];
 }
 
+function getSampleFromOptions(options) {
+  return options.length
+    ? options[0]
+    : options;
+}
+
 // this can be moved into a action and call kepler.gl action
 /**
  *
@@ -122,6 +128,7 @@ function arrayify(thing) {
 export const loadRemoteResourceSuccess = (state, action) => {
   const responses = arrayify(action.response);
   const options = arrayify(action.options);
+  const currentSample = getSampleFromOptions(action.options);
 
   const datasets = options.map((opt, i) => {
     const datasetId = opt.id || generateHashId(6);
@@ -159,7 +166,7 @@ export const loadRemoteResourceSuccess = (state, action) => {
     ...state,
     app: {
       ...state.app,
-      currentSample: action.options,
+      currentSample,
       isMapLoading: false // we turn of the spinner
     },
     keplerGl: {

--- a/examples/demo-app/src/reducers/index.js
+++ b/examples/demo-app/src/reducers/index.js
@@ -159,7 +159,7 @@ export const loadRemoteResourceSuccess = (state, action) => {
     ...state,
     app: {
       ...state.app,
-      currentSample: action.options && action.options.length ? action.options[0] : action.options,
+      currentSample: action.options,
       isMapLoading: false // we turn of the spinner
     },
     keplerGl: {

--- a/examples/demo-app/src/utils/cloud-providers/carto.js
+++ b/examples/demo-app/src/utils/cloud-providers/carto.js
@@ -62,7 +62,7 @@ async function uploadFile({blob, name: fileName, isPublic = true}) {
 
   const cartoDatasets = datasets.map(convertDataset);
 
-  const cs = await carto.CustomStorage;
+  const cs = await carto.getCustomStorage();
 
   const result = await cs.createVisualization({
     name: fileName,
@@ -71,7 +71,7 @@ async function uploadFile({blob, name: fileName, isPublic = true}) {
   }, cartoDatasets, true);
 
   return ({
-    url: `demo/map/carto/${result.id}?owner=${cs.username}`
+    url: `demo/map/carto?mapId=${result.id}&owner=${cs.getSQLClient().username}`
   });
 }
 
@@ -124,11 +124,18 @@ function loadMap(queryParams) {
     dispatch(setLoadingMapStatus(true));
     carto.PublicStorageReader.getVisualization(username, mapId).then((result) => {
       // These are the options required for the action. For now, all datasets that come from CARTO are CSV
-      const options = result.datasets.map((dataset) => ({
+      const options = result.datasets.map((dataset) => {
+        const datasetId = dataset.name.split('keplergl_public_v0_')[1];
+
         // TODO: customStorage should return dataset name without prefix
-        id: dataset.name.split('keplergl_public_v0_')[1],
-        dataUrl: '.csv'
-      }));
+        return {
+          id: datasetId,
+          label: datasetId,
+          description: dataset.description,
+          dataUrl: '',
+          configUrl: ''
+        };
+      });
 
       const datasets = result.datasets.map((dataset) => dataset.file);
 

--- a/examples/demo-app/src/utils/cloud-providers/carto.js
+++ b/examples/demo-app/src/utils/cloud-providers/carto.js
@@ -71,7 +71,7 @@ async function uploadFile({blob, name: fileName, isPublic = true}) {
   }, cartoDatasets, true);
 
   return ({
-    url: `demo/map/carto?mapId=${result.id}&owner=${cs.getSQLClient().username}`
+    url: `demo/map/carto?mapId=${result.id}&owner=${carto.username}`
   });
 }
 
@@ -125,15 +125,16 @@ function loadMap(queryParams) {
     carto.PublicStorageReader.getVisualization(username, mapId).then((result) => {
       // These are the options required for the action. For now, all datasets that come from CARTO are CSV
       const options = result.datasets.map((dataset) => {
+        // TODO: customStorage should return dataset name without prefix
         const datasetId = dataset.name.split('keplergl_public_v0_')[1];
 
-        // TODO: customStorage should return dataset name without prefix
         return {
           id: datasetId,
           label: datasetId,
           description: dataset.description,
           dataUrl: '',
-          configUrl: ''
+          configUrl: '',
+          panelDisabled: true
         };
       });
 


### PR DESCRIPTION
This PR fixes an error produced by `SampleMapPanel` component while rendering because of some mismatching properties in our side while creating data to inject to Kepler.gl.

This is SampleMapPanel component, which is the component showing a preview of the dataset (label, description, data source...etc):
<img width="294" alt="Screenshot 2019-11-06 at 16 12 01" src="https://user-images.githubusercontent.com/4319728/68310472-5ba4ea00-00b0-11ea-8136-bf0946a21e08.png">

I opted to show it even though we don't have much data to display, but we can remove it altogether if we want to.

Related to https://github.com/CartoDB/kepler.gl/issues/32.